### PR TITLE
fix: suppress mix deps.get warning variable "deps" does not exist and is being expanded to "deps()"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: elixir
 elixir:
-  - 1.0.5
-  - 1.1.1
-  - 1.2.6
   - 1.3.2
+  - 1.4.2
 sudo: false
 script:
   - mix test

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule NetSNMP.Mixfile do
       version: "0.0.32",
       name: "NetSNMP",
       source_url: "https://github.com/jonnystorm/net-snmp-elixir",
-      elixir: "~> 1.4",
+      elixir: "> 1.3",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -6,10 +6,10 @@ defmodule NetSNMP.Mixfile do
       version: "0.0.32",
       name: "NetSNMP",
       source_url: "https://github.com/jonnystorm/net-snmp-elixir",
-      elixir: "~> 1.0",
+      elixir: "~> 1.4",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
-      deps: deps,
+      deps: deps(),
       docs: [extras: ["README.md"]]
     ]
   end
@@ -35,7 +35,7 @@ defmodule NetSNMP.Mixfile do
 
   defp deps do
     [ {:snmp_mib_ex, git: "https://github.com/jonnystorm/snmp-mib-elixir"},
-      {:ex_doc, "~> 0.13", only: :dev}
+      {:ex_doc, "~> 0.15", only: :dev}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule NetSNMP.Mixfile do
       version: "0.0.32",
       name: "NetSNMP",
       source_url: "https://github.com/jonnystorm/net-snmp-elixir",
-      elixir: "> 1.3",
+      elixir: "~> 1.3",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       deps: deps(),

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+%{"earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
   "snmp_mib_ex": {:git, "https://github.com/jonnystorm/snmp-mib-elixir", "431f88a730420270ab33431c97948089e24589ce", []}}


### PR DESCRIPTION
1. suppress mix deps.get warning (would benefit from PR merge request for underlying snmp_mib_ex project https://github.com/jonnystorm/snmp-mib-elixir/pull/1
2. update to elixir 1.4
3. update ex_doc and earmark hex packages