### PR TITLE
fix: suppress compiler warning

### DIFF
--- a/lib/net_snmp.ex
+++ b/lib/net_snmp.ex
@@ -16,20 +16,20 @@ defmodule NetSNMP do
 
       iex> NetSNMP.credential [:v1, "public"]
       [version: "1", community: "public"]
-      
+
       iex> NetSNMP.credential [:v2c, "public"]
       [version: "2c", community: "public"]
-      
+
       iex> NetSNMP.credential [:v3, :no_auth_no_priv, "user"]
       [version: "3", sec_level: "noAuthNoPriv", sec_name: "user"]
-      
+
       iex> NetSNMP.credential [:v3, :auth_no_priv, "user", :sha, "authpass"]
       [ version: "3",
         sec_level: "authNoPriv",
         sec_name: "user",
         auth_proto: "sha", auth_pass: "authpass"
       ]
-      
+
       iex> NetSNMP.credential [:v3, :auth_priv, "user", :sha, "authpass", :aes, "privpass"]
       [ version: "3",
         sec_level: "authPriv",
@@ -49,10 +49,10 @@ defmodule NetSNMP do
 
       [:v3, :no_auth_no_priv, _] ->
         apply &credential/3, args
-  
+
       [:v3, :auth_no_priv, _, _, _] ->
         apply &credential/5, args
-  
+
       [:v3, :auth_priv, _, _, _, _, _] ->
         apply &credential/7, args
     end
@@ -65,7 +65,7 @@ defmodule NetSNMP do
 
       iex> NetSNMP.credential :v1, "public"
       [version: "1", community: "public"]
-      
+
       iex> NetSNMP.credential :v2c, "public"
       [version: "2c", community: "public"]
   """
@@ -232,8 +232,8 @@ defmodule NetSNMP do
     ] |> Enum.join(" ")
   end
   defp gen_snmpcmd(:table, snmp_object, uri, credential, context) do
-    max_reps = get_max_repetitions
-    delim = get_field_delimiter
+    max_reps = get_max_repetitions()
+    delim = get_field_delimiter()
 
     [ "snmptable -Le -mALL -Cr #{max_reps} -Clibf '#{delim}' -OXUet -n '#{context}'",
       credential_to_snmpcmd_args(credential),

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{"earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
-  "snmp_mib_ex": {:git, "https://github.com/jonnystorm/snmp-mib-elixir", "431f88a730420270ab33431c97948089e24589ce", []}}
+  "snmp_mib_ex": {:git, "https://github.com/jonnystorm/snmp-mib-elixir", "17a7422c98294631241650260c72edc7fed1230d", []}}


### PR DESCRIPTION
1. variable "get_max_repetitions" does not exist and is being expanded to "get_max_repetitions()"
2. variable "get_field_delimiter" does not exist and is being expanded to "get_field_delimiter()"