### PR TITLE
Parse OID returning empty string without throwing error

### DIFF
--- a/lib/net_snmp/parse.ex
+++ b/lib/net_snmp/parse.ex
@@ -302,6 +302,7 @@ defmodule NetSNMP.Parse do
   defp parse_snmp_output_line(line) do
     try do
       case String.split line, " ", parts: 3 do
+        [oid, "=", "\"\""] -> {oid, :string, ""}
         [oid, "=", type_string_and_value] ->
           case String.split(type_string_and_value, ": ", parts: 2) do
             [type_string, value] ->

--- a/test/net_snmp_test.exs
+++ b/test/net_snmp_test.exs
@@ -44,6 +44,19 @@ Compiled Wed 18-Aug-10 07:55 by prod_rel_team
       ]
   end
 
+  test "parses snmpget/walk output with empty string" do
+    output = "
+.1.3.6.1.2.1.1.6.0 = \"\"
+.1.3.6.1.2.1.1.7.0 = INTEGER: 78
+.1.3.6.1.2.1.1.8.0 = 0"
+
+    assert NetSNMP.Parse.parse_snmp_output(output) ==
+      [ {:ok, %SNMPMIB.Object{oid: [1, 3, 6, 1, 2, 1, 1, 6, 0], type: 4, value: ""}},
+        {:ok, %SNMPMIB.Object{oid: [1, 3, 6, 1, 2, 1, 1, 7, 0], type: 2, value: 78}},
+        {:ok, %SNMPMIB.Object{oid: [1, 3, 6, 1, 2, 1, 1, 8, 0], type: 2, value: "0"}}
+      ]
+  end
+
   test "parses snmptable output" do
     output = "SNMP table: IP-FORWARD-MIB::ipCidrRouteTable
 


### PR DESCRIPTION
Currently, if the SNMP get/walk query returns just an empty string which is not of `type_string_and_value`, a parsing error will be thrown due to the function `String.split(type_string_and_value, ": ", parts: 2)` in `NetSNMP.Parse.parse_snmp_output_line`

When querying against some real-world switches, the following is observed:

```
iex> neighbor_sysnames = NetSNMP.walk(snmp_object, Switch.agent(switch), Switch.credential(switch)) |> Enum.map(fn({:ok, %SNMPMIB.Object{oid: _oid, type: _type, value: val}}) -> val end)

[debug] Output is: '.1.0.8802.1.1.2.1.4.1.1.8.0.21.1 = STRING: "GigabitEthernet1/1/24"
.1.0.8802.1.1.2.1.4.1.1.8.0.23.1 = STRING: "GigabitEthernet1/1/48"
.1.0.8802.1.1.2.1.4.1.1.8.0.23.2 = ""
.1.0.8802.1.1.2.1.4.1.1.8.0.23.3 = ""
.1.0.8802.1.1.2.1.4.1.1.8.0.24.1 = ""
'
[debug] Scrubbed output is: '.1.0.8802.1.1.2.1.4.1.1.8.0.21.1 = STRING: "GigabitEthernet1/1/24"
.1.0.8802.1.1.2.1.4.1.1.8.0.23.1 = STRING: "GigabitEthernet1/1/48"
.1.0.8802.1.1.2.1.4.1.1.8.0.23.2 = ""
.1.0.8802.1.1.2.1.4.1.1.8.0.23.3 = ""
.1.0.8802.1.1.2.1.4.1.1.8.0.24.1 = ""'

[debug] Received something we didn't understand: '.1.0.8802.1.1.2.1.4.1.1.8.0.23.2 = ""'
[debug] Received something we didn't understand: '.1.0.8802.1.1.2.1.4.1.1.8.0.23.3 = ""'
[debug] Received something we didn't understand: '.1.0.8802.1.1.2.1.4.1.1.8.0.24.1 = ""'

["GigabitEthernet1/1/24",
 "GigabitEthernet1/1/48\n.1.0.8802.1.1.2.1.4.1.1.8.0.23.2 = \"\"\n.1.0.8802.1.1.2.1.4.1.1.8.0.23.3 = \"\"\n.1.0.8802.1.1.2.1.4.1.1.8.0.24.1 = \"\""]
```
This behavior is disruptive and difficult to rescue from, as it changes the size of the returned collection and concatenates subsequent OID outputs after the line where the parsing error was triggered.

---

This PR fixes this issue by pattern matching against an OID response with an empty string, i.e. without a `STRING` type. The following output is now observed:

```
iex> neighbor_sysnames = NetSNMP.walk(snmp_object, Switch.agent(switch), Switch.credential(switch)) |> Enum.map(fn({:ok, %SNMPMIB.Object{oid: _oid, type: _type, value: val}}) -> val end)

[debug] Output is: '.1.0.8802.1.1.2.1.4.1.1.8.0.21.1 = STRING: "GigabitEthernet1/1/24"
.1.0.8802.1.1.2.1.4.1.1.8.0.23.1 = STRING: "GigabitEthernet1/1/48"
.1.0.8802.1.1.2.1.4.1.1.8.0.23.2 = ""
.1.0.8802.1.1.2.1.4.1.1.8.0.23.3 = ""
.1.0.8802.1.1.2.1.4.1.1.8.0.24.1 = ""
'
[debug] Scrubbed output is: '.1.0.8802.1.1.2.1.4.1.1.8.0.21.1 = STRING: "GigabitEthernet1/1/24"
.1.0.8802.1.1.2.1.4.1.1.8.0.23.1 = STRING: "GigabitEthernet1/1/48"
.1.0.8802.1.1.2.1.4.1.1.8.0.23.2 = ""
.1.0.8802.1.1.2.1.4.1.1.8.0.23.3 = ""
.1.0.8802.1.1.2.1.4.1.1.8.0.24.1 = ""'

["GigabitEthernet1/1/24", "GigabitEthernet1/1/48", "", "", ""]
```
